### PR TITLE
build: single-source version from __init__.py 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastapi-prometheus-lite"
-version = "0.6.0"
+dynamic = ["version"]
 description = "A minimal and fast Prometheus middleware for FastAPI"
 authors = [
     { name = "Ludovico Conti", email = "" },
@@ -43,6 +43,9 @@ Issues = "https://github.com/luzzodev/fastapi-prometheus-lite/issues"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "fastapi_prometheus_lite/__init__.py"
 
 [tool.hatch.build.targets.sdist]
 include = ["fastapi_prometheus_lite"]


### PR DESCRIPTION
## What                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                   
  Make `fastapi_prometheus_lite/__init__.py` the single source of truth for the package version.                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                   
  - Replace static `version = "0.6.0"` in `pyproject.toml` with `dynamic = ["version"]`                                                                                                                                                                                                                            
  - Add `[tool.hatch.version]` pointing hatchling at `fastapi_prometheus_lite/__init__.py`                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                   
  ## Why                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                   
  The version was duplicated in `pyproject.toml` and `__init__.py`, which drift apart silently. Now `__version__` is canonical and the build backend reads it from there.                                                                                                                                          
                                                                                                                                                                                                                                                                                                                   
  ## Verification                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                   
  - `uvx hatchling version` → `0.6.0`                                                                                                                                                                                                                                                                              
  - `uv build` produces `fastapi_prometheus_lite-0.6.0.tar.gz` + `...-0.6.0-py3-none-any.whl`